### PR TITLE
parser: support multiline shell prompts via prompt_lines config

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,12 @@ preset = "starship"
 
 # Enable Nerd Font icons and Powerline glyphs (default: false)
 # nerd_fonts = true
+
+# For multiline prompts (e.g., starship with a dir/time line above `❯`),
+# set how many terminal lines your prompt occupies. The `prompt` regex
+# should still match the *last* line; the lines above are treated as
+# prompt decoration instead of previous-command output. Default: 1.
+# prompt_lines = 2
 ```
 
 ### Presets

--- a/README.md
+++ b/README.md
@@ -180,25 +180,29 @@ output that resembles your prompt may cause incorrect parsing.
 
 ### Multiline prompts
 
-Some prompts span multiple terminal lines — e.g. a Starship config with a
-directory/time line above the actual `❯` prompt character:
+Some prompts span multiple terminal lines — e.g. default Starship, which
+puts a blank separator and a module line above the `❯` character:
 
 ```
-~/code   08:27:27 AM           ← prompt decoration (line 1)
-main ❯ git remote -v           ← actual prompt + command (line 2)
+                               ← blank separator (line 1, from add_newline)
+~/code on  main                ← prompt decoration (line 2)
+❯ git remote -v                ← actual prompt + command (line 3)
 origin  git@github:foo/bar.git (fetch)
 origin  git@github:foo/bar.git (push)
 ```
 
-By default the parser treats each prompt as a single line, so the `~/code
-08:27:27 AM` decoration gets attached to the *previous* command's output.
-Set `prompt_lines` in your config to tell the parser how many terminal
-lines each prompt occupies:
+By default the parser treats each prompt as a single line, so the blank
+line and `~/code on main` decoration get attached to the *previous*
+command's output. Set `prompt_lines` in your config to tell the parser
+how many terminal lines each prompt occupies:
 
 ```toml
 preset = "starship"
-prompt_lines = 2
+prompt_lines = 3   # blank + modules + ❯ line (default Starship)
 ```
+
+Set `prompt_lines = 2` if you've disabled Starship's `add_newline`, or
+higher if your custom format adds more lines above `❯`.
 
 The `prompt` regex (or `preset`) should still match the *last* line of
 the prompt — the one with the command. The `prompt_lines - 1` decoration

--- a/README.md
+++ b/README.md
@@ -178,6 +178,32 @@ preset for your shell, or configure a custom pattern.
 depends on your prompt configuration. Heavily customized prompts or command
 output that resembles your prompt may cause incorrect parsing.
 
+### Multiline prompts
+
+Some prompts span multiple terminal lines — e.g. a Starship config with a
+directory/time line above the actual `❯` prompt character:
+
+```
+~/code   08:27:27 AM           ← prompt decoration (line 1)
+main ❯ git remote -v           ← actual prompt + command (line 2)
+origin  git@github:foo/bar.git (fetch)
+origin  git@github:foo/bar.git (push)
+```
+
+By default the parser treats each prompt as a single line, so the `~/code
+08:27:27 AM` decoration gets attached to the *previous* command's output.
+Set `prompt_lines` in your config to tell the parser how many terminal
+lines each prompt occupies:
+
+```toml
+preset = "starship"
+prompt_lines = 2
+```
+
+The `prompt` regex (or `preset`) should still match the *last* line of
+the prompt — the one with the command. The `prompt_lines - 1` decoration
+lines directly above it are stripped from the preceding command's output.
+
 ## Configuration
 
 You can persist preferences in `~/.config/tmux-snaglord/config.toml`:
@@ -192,10 +218,8 @@ preset = "starship"
 # Enable Nerd Font icons and Powerline glyphs (default: false)
 # nerd_fonts = true
 
-# For multiline prompts (e.g., starship with a dir/time line above `❯`),
-# set how many terminal lines your prompt occupies. The `prompt` regex
-# should still match the *last* line; the lines above are treated as
-# prompt decoration instead of previous-command output. Default: 1.
+# Number of terminal lines each prompt occupies (default: 1).
+# See "Multiline prompts" above for details.
 # prompt_lines = 2
 ```
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -12,7 +12,8 @@ use clap::ValueEnum;
 
 use crate::action::Action;
 use crate::parser::{
-    CommandBlock, JsonBlock, PathBlock, find_json_candidates, find_path_candidates, parse_history,
+    CommandBlock, JsonBlock, PathBlock, find_json_candidates, find_path_candidates,
+    parse_history_ex,
 };
 use crate::tmux;
 use crate::utils::escape_debug;
@@ -270,6 +271,8 @@ pub struct App {
     // Parsing state
     /// Prompt pattern regex for re-parsing on reload
     prompt_re: Regex,
+    /// Number of terminal lines a single prompt occupies (1 for single-line prompts)
+    prompt_lines: usize,
 
     // Error state
     /// Transient error message to display in UI
@@ -293,6 +296,7 @@ impl App {
         nerd_fonts: bool,
         prompt_pattern: String,
         original_pane_id: String,
+        prompt_lines: usize,
     ) -> Self {
         let mut app = Self {
             mode: Mode::Commands,
@@ -307,6 +311,7 @@ impl App {
             search_query: String::new(),
             is_searching: false,
             prompt_re,
+            prompt_lines,
             error_msg: None,
             show_help: false,
             view_source: ViewSource::Original,
@@ -346,7 +351,7 @@ impl App {
     /// Capture and parse a specific pane, appending to blocks
     fn ingest_pane(&mut self, pane_id: &str) -> Result<()> {
         let content = tmux::capture_pane(pane_id)?;
-        let mut new_blocks = parse_history(&content, &self.prompt_re);
+        let mut new_blocks = parse_history_ex(&content, &self.prompt_re, self.prompt_lines);
 
         // Tag each block with its source pane
         for block in &mut new_blocks {

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,6 +18,13 @@ pub struct Config {
     /// Use Nerd Font / Powerline glyphs (default: false)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub nerd_fonts: Option<bool>,
+    /// Number of terminal lines a single shell prompt occupies (default: 1).
+    /// Set to 2+ for multiline prompts (e.g., starship with a newline before `❯`).
+    /// The `prompt` regex should still match the line containing the actual
+    /// prompt character; this tells the parser how many decorative lines
+    /// above it to treat as part of the prompt rather than prior output.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompt_lines: Option<usize>,
 }
 
 impl Config {

--- a/src/main.rs
+++ b/src/main.rs
@@ -110,6 +110,7 @@ fn run_init(target: Option<&str>) -> Result<()> {
                 preset: Some(preset.name.to_string()),
                 prompt: None,
                 nerd_fonts: None,
+                prompt_lines: None,
             };
 
             let path = config.save()?;
@@ -136,6 +137,9 @@ fn run_tui(args: RunArgs) -> Result<()> {
     // Resolve nerd fonts preference: Config > Default (false)
     let use_nerd_fonts = config.nerd_fonts.unwrap_or(false);
 
+    // Resolve prompt_lines: Config > Default (1). Zero is treated as 1.
+    let prompt_lines = config.prompt_lines.unwrap_or(1).max(1);
+
     // Validate regex early (before potentially slow tmux capture)
     let prompt_re = Regex::new(&prompt_pattern).context(format!(
         "Invalid prompt regex pattern: '{}'",
@@ -146,7 +150,13 @@ fn run_tui(args: RunArgs) -> Result<()> {
     let target_pane_id = tmux::resolve_pane_id(args.target.as_deref())?;
 
     // Create app (loads content from pane internally)
-    let mut app = App::new(prompt_re, use_nerd_fonts, prompt_pattern, target_pane_id);
+    let mut app = App::new(
+        prompt_re,
+        use_nerd_fonts,
+        prompt_pattern,
+        target_pane_id,
+        prompt_lines,
+    );
 
     // Setup terminal
     enable_raw_mode()?;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -263,6 +263,24 @@ fn find_right_prompt_start(s: &str) -> Option<usize> {
 /// continuations). ANSI escape codes are stripped for regex matching but
 /// preserved in the output for display.
 pub fn parse_history(raw_content: &str, prompt_regex: &Regex) -> Vec<CommandBlock> {
+    parse_history_ex(raw_content, prompt_regex, 1)
+}
+
+/// Like `parse_history`, but with a configurable prompt height.
+///
+/// `prompt_lines` is the total number of terminal lines a single shell prompt
+/// occupies. For single-line prompts (the common case) pass 1. For multiline
+/// prompts (e.g., starship with a dir/time header above `❯`) pass 2 or more.
+/// The `prompt_regex` must still match the *last* line of the prompt (the one
+/// containing the command); the `prompt_lines - 1` lines immediately above it
+/// are treated as prompt decoration and stripped from the prior command's
+/// output.
+pub fn parse_history_ex(
+    raw_content: &str,
+    prompt_regex: &Regex,
+    prompt_lines: usize,
+) -> Vec<CommandBlock> {
+    let header_lines = prompt_lines.saturating_sub(1);
     let mut blocks = Vec::new();
     let lines: Vec<&str> = raw_content.lines().collect();
 
@@ -270,6 +288,19 @@ pub fn parse_history(raw_content: &str, prompt_regex: &Regex) -> Vec<CommandBloc
     let mut current_output: Vec<&str> = Vec::new();
     let mut state = CommandState::default();
     let mut last_command: Option<String> = None; // Track last command for deduplication
+
+    // Strip the `header_lines` lines immediately preceding a prompt from the
+    // current output buffer — they're decoration for the upcoming prompt,
+    // not output from the previous command.
+    let strip_header = |buf: &mut Vec<&str>, n: usize| {
+        for _ in 0..n {
+            if buf.last().is_some() {
+                buf.pop();
+            } else {
+                break;
+            }
+        }
+    };
 
     for line in lines {
         // Strip ANSI codes for regex matching and syntax analysis
@@ -293,8 +324,11 @@ pub fn parse_history(raw_content: &str, prompt_regex: &Regex) -> Vec<CommandBloc
         };
 
         if is_valid_prompt && !state.needs_continuation() && !is_duplicate {
-            // New prompt detected and previous command is complete
-            // Push previous block if exists
+            // New prompt detected and previous command is complete.
+            // Strip any decorative header lines (multiline prompts) from the
+            // previous command's output before pushing its block.
+            strip_header(&mut current_output, header_lines);
+
             if !current_command_lines.is_empty() {
                 blocks.push(build_block(
                     &current_command_lines,
@@ -312,7 +346,9 @@ pub fn parse_history(raw_content: &str, prompt_regex: &Regex) -> Vec<CommandBloc
             state.process_line(&clean_line);
             last_command = extracted_cmd;
         } else if is_duplicate {
-            // Skip duplicate prompt lines entirely (don't add to output)
+            // Skip duplicate prompt lines entirely (don't add to output),
+            // but still strip header lines — they belong to this prompt.
+            strip_header(&mut current_output, header_lines);
             continue;
         } else if state.needs_continuation() {
             // Previous line was incomplete, this is a continuation
@@ -321,6 +357,7 @@ pub fn parse_history(raw_content: &str, prompt_regex: &Regex) -> Vec<CommandBloc
         } else if !current_command_lines.is_empty() {
             // Skip empty prompts (match regex but no command) - don't add to output
             if is_prompt_match {
+                strip_header(&mut current_output, header_lines);
                 continue;
             }
             // Command is complete, this is output
@@ -329,7 +366,10 @@ pub fn parse_history(raw_content: &str, prompt_regex: &Regex) -> Vec<CommandBloc
         // Lines before first prompt are ignored
     }
 
-    // Push final block
+    // Push final block. Don't strip headers here — we can't tell whether the
+    // trailing lines are prompt decoration or real output. A trailing bare
+    // prompt (common case) will already have triggered the in-loop strip via
+    // the `is_prompt_match` branch above.
     if !current_command_lines.is_empty() {
         blocks.push(build_block(
             &current_command_lines,
@@ -968,6 +1008,109 @@ mod tests {
         assert_eq!(blocks.len(), 1);
         assert_eq!(blocks[0].clean_command, "$ echo hello");
         assert_eq!(blocks[0].output, "hello");
+    }
+
+    // === Multiline prompt tests (prompt_lines > 1) ===
+
+    #[test]
+    fn test_multiline_prompt_basic() {
+        // Starship-style: dir+time on line 1, ❯ on line 2
+        let content = "\
+~/code   08:00
+❯ ls
+file1
+file2
+~/code   08:01
+❯ pwd
+/home/user/code
+";
+        let re = Regex::new(r"^❯ ").unwrap();
+        let blocks = parse_history_ex(content, &re, 2);
+
+        assert_eq!(blocks.len(), 2);
+        // Newest first
+        assert_eq!(blocks[0].clean_command, "❯ pwd");
+        assert_eq!(blocks[0].output, "/home/user/code");
+        assert_eq!(blocks[1].clean_command, "❯ ls");
+        // The "~/code   08:01" decoration line should NOT be in the ls output
+        assert_eq!(blocks[1].output, "file1\nfile2");
+    }
+
+    #[test]
+    fn test_multiline_prompt_trailing_redraw() {
+        // Capture ends with a bare redrawn prompt (no command yet)
+        let content = "\
+~/code   08:00
+❯ ls
+file1
+~/code   08:01
+❯
+";
+        let re = Regex::new(r"^❯").unwrap();
+        let blocks = parse_history_ex(content, &re, 2);
+
+        assert_eq!(blocks.len(), 1);
+        assert_eq!(blocks[0].clean_command, "❯ ls");
+        assert_eq!(blocks[0].output, "file1");
+    }
+
+    #[test]
+    fn test_multiline_prompt_three_lines() {
+        // Hypothetical 3-line prompt
+        let content = "\
+─── line1 ───
+dir info
+❯ echo hi
+hi
+─── line1 ───
+dir info
+❯ ls
+out
+";
+        let re = Regex::new(r"^❯ ").unwrap();
+        let blocks = parse_history_ex(content, &re, 3);
+
+        assert_eq!(blocks.len(), 2);
+        assert_eq!(blocks[0].clean_command, "❯ ls");
+        assert_eq!(blocks[0].output, "out");
+        assert_eq!(blocks[1].clean_command, "❯ echo hi");
+        assert_eq!(blocks[1].output, "hi");
+    }
+
+    #[test]
+    fn test_single_line_prompt_unchanged_by_ex() {
+        // prompt_lines=1 should behave identically to parse_history
+        let content = "$ echo hello\nhello\n$ ls\nfile1\nfile2\n";
+        let re = Regex::new(r"^\$ ").unwrap();
+        let blocks_ex = parse_history_ex(content, &re, 1);
+        let blocks = parse_history(content, &re);
+
+        assert_eq!(blocks_ex.len(), blocks.len());
+        for (a, b) in blocks_ex.iter().zip(blocks.iter()) {
+            assert_eq!(a.clean_command, b.clean_command);
+            assert_eq!(a.output, b.output);
+        }
+    }
+
+    #[test]
+    fn test_multiline_prompt_short_output_dropped() {
+        // If a command has fewer output lines than header_lines, stripping
+        // shouldn't panic — it just drops what's there.
+        let content = "\
+~/code   08:00
+❯ true
+~/code   08:01
+❯ ls
+file
+";
+        let re = Regex::new(r"^❯ ").unwrap();
+        let blocks = parse_history_ex(content, &re, 2);
+
+        assert_eq!(blocks.len(), 2);
+        assert_eq!(blocks[0].clean_command, "❯ ls");
+        assert_eq!(blocks[0].output, "file");
+        assert_eq!(blocks[1].clean_command, "❯ true");
+        assert_eq!(blocks[1].output, "");
     }
 
     #[test]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -318,7 +318,10 @@ pub fn parse_history_ex(
         // Only treat as duplicate when there's no output yet — if there's output between
         // two identical prompts, they're genuinely separate command runs.
         let is_duplicate = if let (Some(cmd), Some(last)) = (&extracted_cmd, &last_command) {
-            cmd == last && current_output.is_empty()
+            // With multiline prompts, the header lines of this duplicate prompt
+            // are already in `current_output`; treat output-of-length-≤-header
+            // as "no real output between the two prompts".
+            cmd == last && current_output.len() <= header_lines
         } else {
             false
         };
@@ -1011,6 +1014,25 @@ mod tests {
     }
 
     // === Multiline prompt tests (prompt_lines > 1) ===
+
+    #[test]
+    fn test_multiline_prompt_dedup_bug_repro() {
+        // Typed command + post-Enter redraw: tmux captures the same prompt
+        // twice with the decoration between them. Should dedupe to ONE block.
+        let content = "\
+~/code   08:00
+❯ ls
+~/code   08:00
+❯ ls
+file1
+";
+        let re = Regex::new(r"^❯ ").unwrap();
+        let blocks = parse_history_ex(content, &re, 2);
+
+        assert_eq!(blocks.len(), 1, "duplicate prompts should be deduped");
+        assert_eq!(blocks[0].clean_command, "❯ ls");
+        assert_eq!(blocks[0].output, "file1");
+    }
 
     #[test]
     fn test_multiline_prompt_basic() {

--- a/src/presets.rs
+++ b/src/presets.rs
@@ -33,10 +33,12 @@ pub const PRESETS: &[Preset] = &[
         regex: r"^➜  ",
         description: "Oh My Zsh robbyrussell theme",
     },
-    // Starship default symbol
+    // Starship default symbol. `❯` followed by space *or* end-of-line so
+    // bare prompt redraws (where tmux has stripped trailing space) still
+    // match.
     Preset {
         name: "starship",
-        regex: r"^❯ ",
+        regex: r"^❯(?: |$)",
         description: "Starship default prompt",
     },
     // Simple fallbacks


### PR DESCRIPTION
Starship and similar prompts span 2+ terminal lines (e.g., a dir/time
header above the actual ❯ prompt character). The parser previously
treated those header lines as output of the preceding command, which
made snagged output include the next prompt's decoration.

Add a prompt_lines config option: the prompt regex still matches the
last line of the prompt (the one with the command), and the N-1 lines
immediately above it are stripped from the prior command's output.

config:
```
prompt = "^~/"
prompt_lines = 2
```

result:
<img width="1062" height="579" alt="image" src="https://github.com/user-attachments/assets/42da5607-af0d-4b0a-8562-6e4046862159" />
